### PR TITLE
F #2: Add support for LoadBalancer services

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
 CCM_IMG=registry.dev:5005/cloud-provider-opennebula:latest
 ONE_XMLRPC=http://10.2.11.40:2633/RPC2
 ONE_AUTH=oneadmin:asd
+ROUTER_TEMPLATE_NAME=capone131-vr
+PUBLIC_NETWORK_NAME=service
+PRIVATE_NETWORK_NAME=private

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,9 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
-github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/kustomize/default/cloud-controller-manager.yaml
+++ b/kustomize/default/cloud-controller-manager.yaml
@@ -7,8 +7,16 @@ metadata:
 stringData:
   config.yaml: |
     opennebula:
-      ONE_XMLRPC: "${ONE_XMLRPC}"
-      ONE_AUTH: "${ONE_AUTH}"
+      endpoint:
+        ONE_XMLRPC: "${ONE_XMLRPC}"
+        ONE_AUTH: "${ONE_AUTH}"
+      publicNetwork:
+        name: "${PUBLIC_NETWORK_NAME}"
+      privateNetwork:
+        name: "${PRIVATE_NETWORK_NAME}"
+      virtualRouter:
+        templateName: "${ROUTER_TEMPLATE_NAME}"
+        extraContext: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -52,10 +60,11 @@ spec:
           command:
             - /opennebula-cloud-controller-manager
             - --cloud-provider=opennebula
+            - --cluster-name=$(CLUSTER_NAME)
             - --cloud-config=/etc/one/config.yaml
             - --leader-elect=true
             - --use-service-account-credentials
-            - --controllers=cloud-node,cloud-node-lifecycle
+            - --controllers=cloud-node,cloud-node-lifecycle,service-lb-controller
           volumeMounts:
             - name: cloud-config
               mountPath: /etc/one/

--- a/pkg/cloud/helpers.go
+++ b/pkg/cloud/helpers.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024, OpenNebula Project, OpenNebula Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opennebula
+
+import (
+	"encoding/xml"
+	"unsafe"
+
+	goca_dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	goca_vr "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/virtualrouter"
+	goca_vm "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/vm"
+)
+
+func ensureNIC(maybeTemplate interface{}, index int) *goca_dyn.Vector {
+	if index < 0 {
+		return nil
+	}
+
+	nics := make([]*goca_dyn.Vector, 0, 1)
+
+	var template *goca_dyn.Template
+	switch v := maybeTemplate.(type) {
+	case *goca_vm.Template:
+		template = (*goca_dyn.Template)(unsafe.Pointer(v))
+	case *goca_vr.Template:
+		template = (*goca_dyn.Template)(unsafe.Pointer(v))
+	default:
+		return nil
+	}
+
+	for _, maybeNIC := range template.Elements {
+		// NOTE: do NOT use AddNIC()
+		if v, ok := maybeNIC.(*goca_dyn.Vector); ok {
+			if v.XMLName.Local == "NIC" {
+				nics = append(nics, v)
+			}
+		}
+	}
+
+	if index < len(nics) {
+		return nics[index]
+	} else {
+		var nicVec *goca_dyn.Vector
+		for k := len(nics); k <= index; k++ {
+			nicVec = &goca_dyn.Vector{XMLName: xml.Name{Local: "NIC"}}
+			template.Elements = append(template.Elements, nicVec)
+		}
+		return nicVec
+	}
+}

--- a/pkg/cloud/loadbalancer.go
+++ b/pkg/cloud/loadbalancer.go
@@ -1,0 +1,534 @@
+/*
+Copyright 2024, OpenNebula Project, OpenNebula Systems.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opennebula
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
+
+	goca "github.com/OpenNebula/one/src/oca/go/src/goca"
+	goca_dyn "github.com/OpenNebula/one/src/oca/go/src/goca/dynamic"
+	goca_vn "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/virtualnetwork"
+	goca_vr "github.com/OpenNebula/one/src/oca/go/src/goca/schemas/virtualrouter"
+)
+
+type LoadBalancer struct {
+	ctrl           *goca.Controller
+	publicNetwork  *ONEVirtualNetwork
+	privateNetwork *ONEVirtualNetwork
+	virtualRouter  *ONEVirtualRouter
+}
+
+func NewLoadBalancer(cfg OpenNebulaConfig) (cloudprovider.LoadBalancer, error) {
+	ctrl := goca.NewController(goca.NewDefaultClient(goca.OneConfig{
+		Endpoint: cfg.Endpoint.ONE_XMLRPC,
+		Token:    cfg.Endpoint.ONE_AUTH,
+	}))
+	if cfg.PublicNetwork == nil && cfg.PrivateNetwork == nil {
+		return nil, fmt.Errorf("no networks defined")
+	}
+	return &LoadBalancer{
+		ctrl:           ctrl,
+		publicNetwork:  cfg.PublicNetwork,
+		privateNetwork: cfg.PrivateNetwork,
+		virtualRouter:  cfg.VirtualRouter,
+	}, nil
+}
+
+func (lb *LoadBalancer) getLBReservationName(clusterName string) string {
+	return fmt.Sprintf("%s-lb", clusterName)
+}
+
+func (lb *LoadBalancer) findLoadBalancer(clusterName, lbName string) (*goca_vn.VirtualNetwork, int, error) {
+	vnID, err := lb.ctrl.VirtualNetworks().ByName(lb.getLBReservationName(clusterName))
+	if err != nil {
+		if err.Error() == "resource not found" {
+			return nil, -1, nil
+		}
+		return nil, -1, err
+	}
+	vn, err := lb.ctrl.VirtualNetwork(vnID).Info(true)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	arIdx := -1
+	for i, ar := range vn.ARs {
+		v, err := ar.Custom.GetStr("LB_NAME")
+		if err != nil {
+			continue
+		}
+		if v == lbName {
+			arIdx = i
+			break
+		}
+	}
+
+	return vn, arIdx, nil
+}
+
+func (lb *LoadBalancer) GetLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service) (*corev1.LoadBalancerStatus, bool, error) {
+	klog.Infof("GetLoadBalancer(): %s", clusterName)
+
+	vn, arIdx, err := lb.findLoadBalancer(clusterName, lb.GetLoadBalancerName(ctx, clusterName, service))
+	if err != nil {
+		return nil, false, err
+	}
+	if arIdx < 0 {
+		return nil, false, nil
+	}
+
+	return &corev1.LoadBalancerStatus{
+		Ingress: []corev1.LoadBalancerIngress{
+			corev1.LoadBalancerIngress{IP: vn.ARs[arIdx].IP},
+		},
+	}, true, nil
+}
+
+func (lb *LoadBalancer) GetLoadBalancerName(_ context.Context, clusterName string, service *corev1.Service) string {
+	return fmt.Sprintf("%s-%s-%s", clusterName, service.Namespace, service.Name)
+}
+
+func (lb *LoadBalancer) getVRReservationName(clusterName string) string {
+	return fmt.Sprintf("%s-vr", clusterName)
+}
+
+func (lb *LoadBalancer) getPrimaryNetwork() *ONEVirtualNetwork {
+	if lb.publicNetwork != nil {
+		return lb.publicNetwork
+	} else {
+		return lb.privateNetwork
+	}
+}
+
+func (lb *LoadBalancer) ensureVRReservationCreated(clusterName string) (*goca_vn.VirtualNetwork, error) {
+	vnID, err := lb.ctrl.VirtualNetworks().ByName(lb.getVRReservationName(clusterName))
+	if err != nil && err.Error() != "resource not found" {
+		return nil, err
+	}
+	if vnID >= 0 {
+		return lb.ctrl.VirtualNetwork(vnID).Info(true)
+	}
+
+	parentNetwork := lb.getPrimaryNetwork()
+	parentID, err := lb.ctrl.VirtualNetworks().ByName(parentNetwork.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	replicas := 1
+	if lb.virtualRouter.Replicas != nil {
+		replicas = int(*lb.virtualRouter.Replicas)
+	}
+	reserve := &goca_dyn.Template{}
+	reserve.AddPair("NAME", lb.getVRReservationName(clusterName))
+	reserve.AddPair("SIZE", replicas)
+	if parentNetwork.AddressRangeID != nil && *parentNetwork.AddressRangeID >= 0 {
+		reserve.AddPair("AR_ID", *parentNetwork.AddressRangeID)
+	} else {
+		// NOTE: Expecting ETHER type AR at AR_ID=1.
+		reserve.AddPair("AR_ID", 1)
+	}
+	vnID, err = lb.ctrl.VirtualNetwork(parentID).Reserve(reserve.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return lb.ctrl.VirtualNetwork(vnID).Info(true)
+}
+
+func (lb *LoadBalancer) ensureLBReservationCreated(clusterName, lbName string) (*goca_vn.VirtualNetwork, int, error) {
+	vn, arIdx, err := lb.findLoadBalancer(clusterName, lbName)
+	if err != nil {
+		return nil, -1, err
+	}
+	if arIdx >= 0 {
+		return vn, arIdx, nil
+	}
+
+	parentNetwork := lb.getPrimaryNetwork()
+	parentID, err := lb.ctrl.VirtualNetworks().ByName(parentNetwork.Name)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	template := &goca_dyn.Template{}
+	template.AddPair("NAME", lb.getLBReservationName(clusterName))
+	template.AddPair("SIZE", 1)
+	if parentNetwork.AddressRangeID != nil && *parentNetwork.AddressRangeID >= 0 {
+		template.AddPair("AR_ID", *parentNetwork.AddressRangeID)
+	} else {
+		// NOTE: Expecting non-ETHER type AR at AR_ID=0.
+		template.AddPair("AR_ID", 0)
+	}
+	if vn != nil {
+		template.AddPair("NETWORK_ID", vn.ID)
+	}
+	vnID, err := lb.ctrl.VirtualNetwork(parentID).Reserve(template.String())
+	if err != nil {
+		return nil, -1, err
+	}
+	vn, err = lb.ctrl.VirtualNetwork(vnID).Info(true)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	arIdx = len(vn.ARs) - 1
+	if arIdx >= 0 {
+		arVec := &goca_dyn.Vector{XMLName: xml.Name{Local: "AR"}}
+		arVec.AddPair("AR_ID", vn.ARs[arIdx].ID)
+		arVec.AddPair("LB_NAME", lbName)
+
+		if err := lb.ctrl.VirtualNetwork(vnID).UpdateAR(arVec.String()); err != nil {
+			return nil, -1, err
+		}
+	}
+
+	vn, err = lb.ctrl.VirtualNetwork(vnID).Info(true)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	hold := &goca_dyn.Vector{XMLName: xml.Name{Local: "LEASES"}}
+	hold.AddPair("IP", vn.ARs[len(vn.ARs)-1].IP)
+	if err := lb.ctrl.VirtualNetwork(vnID).Hold(hold.String()); err != nil {
+		return nil, -1, err
+	}
+
+	return vn, arIdx, nil
+}
+
+func (lb *LoadBalancer) getVirtualRouterName(clusterName string) string {
+	return fmt.Sprintf("%s-lb", clusterName)
+}
+
+func (lb *LoadBalancer) ensureVirtualRouterCreated(clusterName string) (*goca_vr.VirtualRouter, error) {
+	vrID, err := lb.ctrl.VirtualRouterByName(lb.getVirtualRouterName(clusterName))
+	if err != nil && err.Error() != "resource not found" {
+		return nil, err
+	}
+	if vrID >= 0 {
+		return lb.ctrl.VirtualRouter(vrID).Info(true)
+	}
+
+	vmTemplateID, err := lb.ctrl.Templates().ByName(lb.virtualRouter.TemplateName)
+	if err != nil {
+		return nil, err
+	}
+	vmTemplate, err := lb.ctrl.Template(vmTemplateID).Info(false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	vrTemplate := goca_vr.NewTemplate()
+	vrTemplate.Add("NAME", lb.getVirtualRouterName(clusterName))
+	// Overwrite NIC 0 or 0 and 1, leave others intact.
+	nicIndex := -1
+	if lb.publicNetwork != nil {
+		nicIndex++
+		nicVec := ensureNIC(vrTemplate, nicIndex)
+		nicVec.AddPair("NETWORK", lb.getVRReservationName(clusterName))
+	}
+	if lb.privateNetwork != nil {
+		nicIndex++
+		nicVec := ensureNIC(vrTemplate, nicIndex)
+		nicVec.AddPair("NETWORK", lb.privateNetwork.Name)
+		nicVec.AddPair("FLOATING_IP", "YES")
+		if lb.privateNetwork.FloatingIP != nil && net.ParseIP(*lb.privateNetwork.FloatingIP) != nil {
+			nicVec.AddPair("IP", *lb.privateNetwork.FloatingIP)
+		}
+		if lb.privateNetwork.FloatingOnly == nil || !*lb.privateNetwork.FloatingOnly {
+			nicVec.AddPair("FLOATING_ONLY", "NO")
+		} else {
+			nicVec.AddPair("FLOATING_ONLY", "YES")
+		}
+	}
+	vrID, err = lb.ctrl.VirtualRouters().Create(vrTemplate.String())
+	if err != nil {
+		return nil, err
+	}
+
+	contextVec, err := vmTemplate.Template.GetVector("CONTEXT")
+	if err != nil {
+		return nil, err
+	}
+	contextVec.Del("ONEAPP_VNF_HAPROXY_ENABLED")
+	contextVec.AddPair("ONEAPP_VNF_HAPROXY_ENABLED", "YES")
+	if lb.virtualRouter.ExtraContext != nil {
+		for k, v := range lb.virtualRouter.ExtraContext {
+			contextVec.Del(k)
+			contextVec.AddPair(k, v)
+		}
+	}
+	replicas := 1
+	if lb.virtualRouter.Replicas != nil {
+		replicas = int(*lb.virtualRouter.Replicas)
+	}
+	if _, err := lb.ctrl.VirtualRouter(vrID).Instantiate(
+		replicas,
+		vmTemplateID,
+		"",    // name
+		false, // hold
+		vmTemplate.Template.String(),
+	); err != nil {
+		return nil, err
+	}
+
+	return lb.ctrl.VirtualRouter(vrID).Info(true)
+}
+
+func (lb *LoadBalancer) reindexLoadBalancers(vn *goca_vn.VirtualNetwork, contextVec *goca_dyn.Vector, update []map[string]string) {
+	byLB := map[string]map[string]string{}
+	for _, p := range contextVec.Pairs {
+		if strings.HasPrefix(p.Key(), "ONEAPP_VNF_HAPROXY_LB") {
+			t := strings.Split(p.Key(), "_")
+			if _, ok := byLB[t[3]]; !ok {
+				byLB[t[3]] = map[string]string{}
+			}
+			byLB[t[3]][strings.Join(t[4:], "_")] = p.Value
+		}
+	}
+
+	filter := map[string]struct{}{}
+	for _, ar := range vn.ARs {
+		filter[ar.IP] = struct{}{}
+	}
+
+	if len(update) > 0 {
+		for _, v := range byLB {
+			if v["IP"] == update[0]["IP"] {
+				continue
+			}
+			if _, ok := filter[v["IP"]]; !ok {
+				continue
+			}
+			update = append(update, v)
+		}
+	} else {
+		for _, v := range byLB {
+			if _, ok := filter[v["IP"]]; !ok {
+				continue
+			}
+			update = append(update, v)
+		}
+	}
+
+	// Delete everything.
+	for i, s := 0, len(contextVec.Pairs); i < s; {
+		k := contextVec.Pairs[i].Key()
+		switch {
+		case strings.HasPrefix(k, "ONEAPP_VROUTER_ETH0_VIP"), strings.HasPrefix(k, "ONEAPP_VNF_HAPROXY_LB"):
+			contextVec.Pairs = append(contextVec.Pairs[:i], contextVec.Pairs[i+1:]...)
+			s--
+		default:
+			i++
+		}
+	}
+
+	// Reconstruct everything.
+	for i, ar := range vn.ARs {
+		contextVec.AddPair(fmt.Sprintf("ONEAPP_VROUTER_ETH0_VIP%d", i), ar.IP)
+	}
+	for i, v := range update {
+		for x, y := range v {
+			contextVec.AddPair(fmt.Sprintf("ONEAPP_VNF_HAPROXY_LB%d_%s", i, x), y)
+		}
+	}
+}
+
+func (lb *LoadBalancer) updateVirtualRouterInstances(vr *goca_vr.VirtualRouter, vn *goca_vn.VirtualNetwork, arIdx int, service *corev1.Service, nodes []*corev1.Node) error {
+	for _, vmID := range vr.VMs.ID {
+		vm, err := lb.ctrl.VM(vmID).Info(true)
+		if err != nil {
+			return err
+		}
+		contextVec, err := vm.Template.GetVector("CONTEXT")
+		if err != nil {
+			return err
+		}
+
+		update := []map[string]string{}
+		if nodes != nil {
+			for _, port := range service.Spec.Ports {
+				v := map[string]string{
+					"IP":   vn.ARs[arIdx].IP,
+					"PORT": fmt.Sprint(port.Port),
+				}
+				for i, node := range nodes {
+					var nodeIP string
+					for _, addr := range node.Status.Addresses {
+						if addr.Type == corev1.NodeInternalIP {
+							nodeIP = addr.Address
+							break
+						}
+					}
+					if net.ParseIP(nodeIP) != nil {
+						v[fmt.Sprintf("SERVER%d_HOST", i)] = nodeIP
+						v[fmt.Sprintf("SERVER%d_PORT", i)] = fmt.Sprint(port.NodePort)
+					}
+				}
+				update = append(update, v)
+			}
+		}
+		lb.reindexLoadBalancers(vn, contextVec, update)
+
+		if err := lb.ctrl.VM(vmID).UpdateConf(vm.Template.String()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (lb *LoadBalancer) EnsureLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) (*corev1.LoadBalancerStatus, error) {
+	klog.Infof("EnsureLoadBalancer(): %s", clusterName)
+
+	_, err := lb.ensureVRReservationCreated(clusterName)
+	if err != nil {
+		return nil, err
+	}
+	vn, arIdx, err := lb.ensureLBReservationCreated(clusterName, lb.GetLoadBalancerName(ctx, clusterName, service))
+	if err != nil {
+		return nil, err
+	}
+
+	vr, err := lb.ensureVirtualRouterCreated(clusterName)
+	if err != nil {
+		return nil, err
+	}
+	if err := lb.updateVirtualRouterInstances(vr, vn, arIdx, service, nodes); err != nil {
+		return nil, err
+	}
+
+	return &corev1.LoadBalancerStatus{
+		Ingress: []corev1.LoadBalancerIngress{
+			corev1.LoadBalancerIngress{IP: vn.ARs[arIdx].IP},
+		},
+	}, nil
+}
+
+func (lb *LoadBalancer) UpdateLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) error {
+	klog.Infof("UpdateLoadBalancer(): %s", clusterName)
+
+	vrID, err := lb.ctrl.VirtualRouterByName(lb.getVirtualRouterName(clusterName))
+	if err != nil {
+		return err
+	}
+	vr, err := lb.ctrl.VirtualRouter(vrID).Info(true)
+	if err != nil {
+		return err
+	}
+
+	vn, arIdx, err := lb.findLoadBalancer(clusterName, lb.GetLoadBalancerName(ctx, clusterName, service))
+	if err != nil {
+		return err
+	}
+	if arIdx < 0 {
+		return nil
+	}
+
+	if err := lb.updateVirtualRouterInstances(vr, vn, arIdx, service, nodes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (lb *LoadBalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *corev1.Service) error {
+	klog.Infof("EnsureLoadBalancerDeleted(): %s", clusterName)
+
+	vn, arIdx, err := lb.findLoadBalancer(clusterName, lb.GetLoadBalancerName(ctx, clusterName, service))
+	if err != nil {
+		return err
+	}
+	if arIdx < 0 {
+		return nil
+	}
+
+	switch len(vn.ARs) {
+	default:
+		arID, err := strconv.Atoi(vn.ARs[arIdx].ID)
+		if err != nil {
+			return err
+		}
+		release := &goca_dyn.Vector{XMLName: xml.Name{Local: "LEASES"}}
+		release.AddPair("IP", vn.ARs[arIdx].IP)
+		if err := lb.ctrl.VirtualNetwork(vn.ID).Release(release.String()); err != nil {
+			return err
+		}
+		if err := lb.ctrl.VirtualNetwork(vn.ID).RmAR(arID); err != nil {
+			return err
+		}
+		vn, err = lb.ctrl.VirtualNetwork(vn.ID).Info(true)
+		if err != nil {
+			return err
+		}
+
+		vrID, err := lb.ctrl.VirtualRouterByName(lb.getVirtualRouterName(clusterName))
+		if err != nil {
+			return err
+		}
+		vr, err := lb.ctrl.VirtualRouter(vrID).Info(true)
+		if err != nil {
+			return err
+		}
+		if err := lb.updateVirtualRouterInstances(vr, vn, arIdx, service, nil); err != nil {
+			return err
+		}
+	case 1: // Since this is the last item in the reservation then VR itself can be removed.
+		vrID, err := lb.ctrl.VirtualRouterByName(lb.getVirtualRouterName(clusterName))
+		if err != nil && err.Error() != "resource not found" {
+			return err
+		}
+		if vrID >= 0 {
+			if err := lb.ctrl.VirtualRouter(vrID).Delete(); err != nil {
+				return err
+			}
+		}
+
+		if vnID, err := lb.ctrl.VirtualNetworks().ByName(lb.getVRReservationName(clusterName)); err != nil {
+			klog.Error(err)
+		} else {
+			if err = lb.ctrl.VirtualNetwork(vnID).Delete(); err != nil {
+				return err
+			}
+		}
+
+		// The LB-reservation VN *must* be deleted last.
+		for _, ar := range vn.ARs {
+			release := &goca_dyn.Vector{XMLName: xml.Name{Local: "LEASES"}}
+			release.AddPair("IP", ar.IP)
+			if err := lb.ctrl.VirtualNetwork(vn.ID).Release(release.String()); err != nil {
+				return err
+			}
+		}
+		if err := lb.ctrl.VirtualNetwork(vn.ID).Delete(); err != nil {
+			return err
+		}
+	case 0: // Should never happen.
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Implement the LoadBalancer interface
- Deploy dedicated VR instance
- Use statically configured HAProxy
- Use VN Reservation to track VIP allocations
- Hold / Release allocated IPs
- Minor variable rename