### PR TITLE
F #-: Adds multi-arch image build Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,25 @@ docker-publish: docker-build
 	$(CONTAINER_TOOL) tag $(CCM_IMG) $(RELEASE_IMG)
 	$(CONTAINER_TOOL) push $(RELEASE_IMG)
 
+# _PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - be able to use docker buildx. More info: https://docs.docker.com/reference/cli/docker/buildx/
+# - have enabled BuildKit. More info:h ttps://docs.docker.com/build/buildkit/
+# - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
+# To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
+# NOTE: BUILDPLATFORM is a Docker BuildKit build-time variable that represents the platform (architecture/OS) on which the build is running (for example, linux/amd64).
+# More info: https://docs.docker.com/build/building/multi-platform/#automatic-platform-args-in-the-global-scope
+_PLATFORMS ?= linux/arm64,linux/amd64
+.PHONY: docker-multiarch-build-and-push
+docker-multiarch-build-and-push: ## Build and push docker image for the manager for cross-platform support)
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile (https://docs.docker.com/build/building/multi-platform/#cross-compilation)
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- $(CONTAINER_TOOL) buildx create --name cloud-provider-opennebula-builder
+	$(CONTAINER_TOOL) buildx use cloud-provider-opennebula-builder
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(_PLATFORMS) --tag ${CCM_IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx rm cloud-provider-opennebula-builder
+	rm Dockerfile.cross
+
 # Deployment
 
 ifndef ignore-not-found


### PR DESCRIPTION
This `docker-multiarch-build-and-push` Makefile recipe allows to create cloud provider docker images for `linux/arm64` and `linux/amd64` architectures.