### PR TITLE
F cluster-api-provider-opennebula#23: Adds disk parameters from storage class

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20241029141545-0bd451171fb6
+	github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20250724115753-099f00ab9435
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20241029141545-0bd451171fb6 h1:YbqDFcJP645B+9qU5lYFe3lXVh9STBQhk/BNvAyPRuU=
 github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20241029141545-0bd451171fb6/go.mod h1:dvAwZi1Aol7eu6BENzHtl8ztGBkacB9t/fJj+fYk+Xg=
+github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20250724115753-099f00ab9435 h1:inCkvuMt6zzGgUORK2nzuaj17SkbV9MBuc38IfG/vCM=
+github.com/OpenNebula/one/src/oca/go/src/goca v0.0.0-20250724115753-099f00ab9435/go.mod h1:dvAwZi1Aol7eu6BENzHtl8ztGBkacB9t/fJj+fYk+Xg=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/csi/driver/controllerserver.go
+++ b/pkg/csi/driver/controllerserver.go
@@ -103,6 +103,7 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		Volume: &csi.Volume{
 			VolumeId:      req.Name,
 			CapacityBytes: requiredBytes,
+			VolumeContext: req.GetParameters(), //pass request parameters as volume context
 		},
 	}, nil
 }
@@ -170,9 +171,11 @@ func (s *ControllerServer) ControllerPublishVolume(ctx context.Context, req *csi
 
 	// TODO: Validate VolumeCapability
 
+	params := req.GetVolumeContext()
+
 	klog.V(3).InfoS("Attaching volume to node",
 		"method", "ControllerPublishVolume", "volumeID", volumeID, "nodeID", nodeID)
-	err = s.volumeProvider.AttachVolume(ctx, req.VolumeId, req.NodeId)
+	err = s.volumeProvider.AttachVolume(ctx, req.VolumeId, req.NodeId, params)
 	if err != nil {
 		klog.V(0).ErrorS(err, "Failed to attach volume",
 			"method", "ControllerPublishVolume", "volumeID", req.VolumeId, "nodeID", req.NodeId)

--- a/pkg/csi/driver/controllerserver.go
+++ b/pkg/csi/driver/controllerserver.go
@@ -77,6 +77,7 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 				Volume: &csi.Volume{
 					VolumeId:      req.Name,
 					CapacityBytes: requiredBytes,
+					VolumeContext: req.GetParameters(), //pass request parameters as volume context
 				},
 			}, nil
 		} else {

--- a/pkg/csi/driver/controllerserver.go
+++ b/pkg/csi/driver/controllerserver.go
@@ -87,9 +87,11 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		}
 	}
 
+	params := req.GetParameters()
+
 	klog.V(3).InfoS("Creating new volume", "volumeName", req.Name, "requiredBytes", requiredBytes)
 
-	err := s.volumeProvider.CreateVolume(ctx, req.Name, requiredBytes, DefaultDriverName)
+	err := s.volumeProvider.CreateVolume(ctx, req.Name, requiredBytes, DefaultDriverName, params)
 	if err != nil {
 		klog.V(0).ErrorS(err, "Failed to create volume",
 			"method", "CreateVolume", "volumeName", req.Name, "requiredBytes", requiredBytes, "defaultDriverName", DefaultDriverName)

--- a/pkg/csi/driver/controllerserver_test.go
+++ b/pkg/csi/driver/controllerserver_test.go
@@ -441,8 +441,8 @@ type MockOpenNebulaVolumeProviderTestify struct {
 	mock.Mock
 }
 
-func (m *MockOpenNebulaVolumeProviderTestify) CreateVolume(ctx context.Context, name string, size int64, owner string) error {
-	args := m.Called(ctx, name, size, owner)
+func (m *MockOpenNebulaVolumeProviderTestify) CreateVolume(ctx context.Context, name string, size int64, owner string, params map[string]string) error {
+	args := m.Called(ctx, name, size, owner, params)
 	return args.Error(0)
 }
 

--- a/pkg/csi/driver/controllerserver_test.go
+++ b/pkg/csi/driver/controllerserver_test.go
@@ -451,8 +451,8 @@ func (m *MockOpenNebulaVolumeProviderTestify) DeleteVolume(ctx context.Context, 
 	return args.Error(0)
 }
 
-func (m *MockOpenNebulaVolumeProviderTestify) AttachVolume(ctx context.Context, volume string, node string) error {
-	args := m.Called(ctx, volume, node)
+func (m *MockOpenNebulaVolumeProviderTestify) AttachVolume(ctx context.Context, volume string, node string, params map[string]string) error {
+	args := m.Called(ctx, volume, node, params)
 	return args.Error(0)
 }
 
@@ -461,8 +461,8 @@ func (m *MockOpenNebulaVolumeProviderTestify) DetachVolume(ctx context.Context, 
 	return args.Error(0)
 }
 
-func (m *MockOpenNebulaVolumeProviderTestify) ListVolumes(ctx context.Context, volume string) ([]string, error) {
-	args := m.Called(ctx, volume)
+func (m *MockOpenNebulaVolumeProviderTestify) ListVolumes(ctx context.Context, volume string, maxEntries int32, startingToken string) ([]string, error) {
+	args := m.Called(ctx, volume, maxEntries, startingToken)
 	return args.Get(0).([]string), args.Error(1)
 }
 

--- a/pkg/csi/opennebula/opennebula.go
+++ b/pkg/csi/opennebula/opennebula.go
@@ -38,7 +38,7 @@ type OpenNebulaProvider struct {
 type OpenNebulaVolumeProvider interface {
 	CreateVolume(ctx context.Context, name string, size int64, owner string) error
 	DeleteVolume(ctx context.Context, volume string) error
-	AttachVolume(ctx context.Context, volume string, node string) error
+	AttachVolume(ctx context.Context, volume string, node string, params map[string]string) error
 	DetachVolume(ctx context.Context, volume string, node string) error
 	ListVolumes(ctx context.Context, owner string, maxEntries int32, startingToken string) ([]string, error)
 	GetCapacity(ctx context.Context) (int64, error)

--- a/pkg/csi/opennebula/opennebula.go
+++ b/pkg/csi/opennebula/opennebula.go
@@ -36,7 +36,7 @@ type OpenNebulaProvider struct {
 }
 
 type OpenNebulaVolumeProvider interface {
-	CreateVolume(ctx context.Context, name string, size int64, owner string) error
+	CreateVolume(ctx context.Context, name string, size int64, owner string, params map[string]string) error
 	DeleteVolume(ctx context.Context, volume string) error
 	AttachVolume(ctx context.Context, volume string, node string, params map[string]string) error
 	DetachVolume(ctx context.Context, volume string, node string) error

--- a/pkg/csi/opennebula/persistentdisk.go
+++ b/pkg/csi/opennebula/persistentdisk.go
@@ -108,7 +108,7 @@ func (p *PersistentDiskVolumeProvider) DeleteVolume(ctx context.Context, volume 
 	return nil
 }
 
-func (p *PersistentDiskVolumeProvider) AttachVolume(ctx context.Context, volume, node string) error {
+func (p *PersistentDiskVolumeProvider) AttachVolume(ctx context.Context, volume string, node string, params map[string]string) error {
 	nodeID, err := p.NodeExists(ctx, node)
 	if err != nil || nodeID == -1 {
 		return fmt.Errorf("failed to check if node exists: %w", err)
@@ -120,6 +120,7 @@ func (p *PersistentDiskVolumeProvider) AttachVolume(ctx context.Context, volume,
 	}
 	disk := shared.NewDisk()
 	disk.Add(shared.ImageID, volumeID)
+	addDiskParams(disk, params)
 
 	err = p.ctrl.VM(nodeID).DiskAttach(disk.String())
 	if err != nil {
@@ -131,6 +132,66 @@ func (p *PersistentDiskVolumeProvider) AttachVolume(ctx context.Context, volume,
 		return fmt.Errorf("failed to wait for node readiness: %w", err)
 	}
 	return nil
+}
+
+func addDiskParams(disk *shared.Disk, params map[string]string) {
+	for key, val := range params {
+		if val == "" {
+			continue
+		}
+		switch key {
+		case "devPrefix":
+			disk.Add(shared.DevPrefix, val)
+		case "cache":
+			disk.Add(shared.Cache, val)
+		case "driver":
+			disk.Add(shared.Driver, val)
+		case "io":
+			disk.Add(shared.IO, val)
+		case "ioThread":
+			disk.Add(shared.IOThread, val)
+		case "virtioBLKQueues":
+			disk.Add(shared.VirtioBLKQueues, val)
+		case "totalBytesSec":
+			disk.Add(shared.TotalBytesSec, val)
+		case "readBytesSec":
+			disk.Add(shared.ReadBytesSec, val)
+		case "writeBytesSec":
+			disk.Add(shared.WriteBytesSec, val)
+		case "totalIOPSSec":
+			disk.Add(shared.TotalIOPSSec, val)
+		case "readIOPSSec":
+			disk.Add(shared.ReadIOPSSec, val)
+		case "writeIOPSSec":
+			disk.Add(shared.WriteIOPSSec, val)
+		case "totalBytesSecMax":
+			disk.Add(shared.TotalBytesSecMax, val)
+		case "readBytesSecMax":
+			disk.Add(shared.ReadBytesSecMax, val)
+		case "writeBytesSecMax":
+			disk.Add(shared.WriteBytesSecMax, val)
+		case "totalIOPSSecMax":
+			disk.Add(shared.TotalIOPSSecMax, val)
+		case "readIOPSSecMax":
+			disk.Add(shared.ReadIOPSSecMax, val)
+		case "writeIOPSSecMax":
+			disk.Add(shared.WriteIOPSSecMax, val)
+		case "totalBytesSecMaxLength":
+			disk.Add(shared.TotalBytesSecMaxLength, val)
+		case "readBytesSecMaxLength":
+			disk.Add(shared.ReadBytesSecMaxLength, val)
+		case "writeBytesSecMaxLength":
+			disk.Add(shared.WriteBytesSecMaxLength, val)
+		case "totalIOPSSecMaxLength":
+			disk.Add(shared.TotalIOPSSecMaxLength, val)
+		case "readIOPSSecMaxLength":
+			disk.Add(shared.ReadIOPSSecMaxLength, val)
+		case "writeIOPSSecMaxLength":
+			disk.Add(shared.WriteIOPSSecMaxLength, val)
+		case "sizeIOPSSec":
+			disk.Add(shared.SizeIOPSSec, val)
+		}
+	}
 }
 
 func (p *PersistentDiskVolumeProvider) DetachVolume(ctx context.Context, volume, node string) error {

--- a/pkg/csi/opennebula/persistentdisk.go
+++ b/pkg/csi/opennebula/persistentdisk.go
@@ -50,7 +50,7 @@ func NewPersistentDiskVolumeProvider(client *OpenNebulaClient) (*PersistentDiskV
 	}, nil
 }
 
-func (p *PersistentDiskVolumeProvider) CreateVolume(ctx context.Context, name string, size int64, owner string) error {
+func (p *PersistentDiskVolumeProvider) CreateVolume(ctx context.Context, name string, size int64, owner string, params map[string]string) error {
 	if name == "" {
 		return fmt.Errorf("volume name cannot be empty")
 	}
@@ -71,6 +71,10 @@ func (p *PersistentDiskVolumeProvider) CreateVolume(ctx context.Context, name st
 	tpl.Add(imk.Persistent, "YES")
 	tpl.AddPair(ownerTag, owner)
 	tpl.Add(imk.Type, string(image.Datablock))
+
+	if params != nil && params["devPrefix"] != "" {
+		tpl.Add(imk.DevPrefix, params["devPrefix"])
+	}
 
 	imageID, err := p.ctrl.Images().Create(tpl.String(), 1)
 	if err != nil {

--- a/pkg/csi/opennebula/persistentdisk_test.go
+++ b/pkg/csi/opennebula/persistentdisk_test.go
@@ -62,8 +62,12 @@ func TestPersistentDiskLifecycle(t *testing.T) {
 
 	ctx := context.Background()
 
+	params := map[string]string{
+		"devPrefix": "vd",
+	}
+
 	volumeTestName := fmt.Sprintf("%s-%s", volumeName, uuid.New().String())
-	err = volumeProvider.CreateVolume(ctx, volumeTestName, volumeSize, testDriverName)
+	err = volumeProvider.CreateVolume(ctx, volumeTestName, volumeSize, testDriverName, params)
 	if err != nil {
 		t.Fatalf("failed to create volume: %v", err)
 	}


### PR DESCRIPTION
Allows to specify disk parameters on the storage class for the attached disk, e.g.
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: opennebula-fs
  annotations:
    storageclass.kubernetes.io/is-default-class: "false"
provisioner: csi.opennebula.io
reclaimPolicy: Delete
allowVolumeExpansion: false
mountOptions: []
volumeBindingMode: Immediate
parameters:
  fsType: "ext4"
  devPrefix: "vd"
  virtioBLKQueues: "4"
  cache: "writethrough"
  totalBytesSec: "1000000" # 1MB/s
```