### PR TITLE
F OpenNebula/cluster-api-provider-opennebula#50: Add support for ReadOnlyMany

### DIFF
--- a/pkg/csi/driver/nodeserver.go
+++ b/pkg/csi/driver/nodeserver.go
@@ -106,6 +106,15 @@ func (ns *NodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 		fsType = defaultFSType
 	}
 
+	accessMode := volumeCapability.GetAccessMode().Mode
+	if accessMode == csi.VolumeCapability_AccessMode_UNKNOWN {
+		return nil, status.Error(codes.InvalidArgument, "access mode is required")
+	}
+
+	if accessMode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+		mountFlags = append(mountFlags, "ro")
+	}
+
 	// Check if device path for volumeID exists
 	if _, err := os.Stat(devicePath); os.IsNotExist(err) {
 		klog.V(0).ErrorS(err, "Device path does not exist",

--- a/pkg/csi/opennebula/opennebula.go
+++ b/pkg/csi/opennebula/opennebula.go
@@ -36,9 +36,9 @@ type OpenNebulaProvider struct {
 }
 
 type OpenNebulaVolumeProvider interface {
-	CreateVolume(ctx context.Context, name string, size int64, owner string, params map[string]string) error
+	CreateVolume(ctx context.Context, name string, size int64, owner string, immutable bool, fsType string, params map[string]string) error
 	DeleteVolume(ctx context.Context, volume string) error
-	AttachVolume(ctx context.Context, volume string, node string, params map[string]string) error
+	AttachVolume(ctx context.Context, volume string, node string, immutable bool, params map[string]string) error
 	DetachVolume(ctx context.Context, volume string, node string) error
 	ListVolumes(ctx context.Context, owner string, maxEntries int32, startingToken string) ([]string, error)
 	GetCapacity(ctx context.Context) (int64, error)

--- a/pkg/csi/opennebula/persistentdisk_test.go
+++ b/pkg/csi/opennebula/persistentdisk_test.go
@@ -67,7 +67,7 @@ func TestPersistentDiskLifecycle(t *testing.T) {
 	}
 
 	volumeTestName := fmt.Sprintf("%s-%s", volumeName, uuid.New().String())
-	err = volumeProvider.CreateVolume(ctx, volumeTestName, volumeSize, testDriverName, params)
+	err = volumeProvider.CreateVolume(ctx, volumeTestName, volumeSize, testDriverName, false, "ext4", params)
 	if err != nil {
 		t.Fatalf("failed to create volume: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestPersistentDiskLifecycle(t *testing.T) {
 	// Sleep to allow the volume to be ready
 	time.Sleep(5 * time.Second)
 
-	volumes, err := volumeProvider.ListVolumes(ctx, testDriverName, -1, "")
+	volumes, err := volumeProvider.ListVolumes(ctx, testDriverName, 10, "")
 	if err != nil {
 		t.Fatalf("failed to list volumes: %v", err)
 	}


### PR DESCRIPTION
This PR allows defining PVCs with the access mode set to `ReadOnlyMany` and formats file systems on the controller side.